### PR TITLE
Bugfix - Raises AttributeError on access to Integer field

### DIFF
--- a/custard/builder.py
+++ b/custard/builder.py
@@ -178,7 +178,7 @@ class CustomFieldsBuilder(object):
             content_object = generic.GenericForeignKey('content_type', 'object_id')
 
             value_text = models.TextField(blank=True, null=True)
-            value_integer = models.IntegerField(blank=True, null=True)
+            value_int = models.IntegerField(blank=True, null=True)
             value_float = models.FloatField(blank=True, null=True)
             value_time = models.TimeField(blank=True, null=True)
             value_date = models.DateField(blank=True, null=True)


### PR DESCRIPTION
When you get or set integer, value ``AttributeError`` has been raised in ``_get_value`` or ``_set_value``.

Error:
```
*** AttributeError: 'CustomValuesModel' object has no attribute 'value_int'
```

Fix problem:
* change name field from ``value_integer`` to ``value_int``